### PR TITLE
Replace freenode references with libera chat

### DIFF
--- a/scan-data/packages/python-sample/README.rst
+++ b/scan-data/packages/python-sample/README.rst
@@ -198,10 +198,10 @@ For discussions and chats, we have:
   Gitter is also accessible via an `IRC bridge <https://irc.gitter.im/>`_.
   There are other AboutCode project-specific channels available there too.
 
-* an official `#aboutcode` IRC channel on freenode (server chat.freenode.net).
+* an official `#aboutcode` IRC channel on liberachat (server web.libera.chat).
   This channel receives build and commit notifications and can be noisy.
   You can use your favorite IRC client or use the `web chat 
-  <https://webchat.freenode.net/>`_.
+  <https://web.libera.chat/?#aboutcode>`_.
 
 
 Source code and downloads


### PR DESCRIPTION
**Reference Issues/PRs**

Fixes [Replace references to freenode #92](https://github.com/nexB/aboutcode/issues/92)

**What does this implement/fix? Explain your changes.**
There were some outdated freenode references present in REAMDE.rst so replaced this address with the official IRC channel i.e Gitter and liberachat

**Any other comments?**
Thank You!